### PR TITLE
Base ADRs, role definitions, and assignments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,3 +13,143 @@ __ https://discuss.openedx.org/c/working-groups/build-test-release/30
 More details about the working group are at the `BTR page in the wiki`__.
 
 __ https://openedx.atlassian.net/wiki/spaces/COMM/pages/1022099494/Build+-+Test+-+Release+Working+Group
+
+================================
+Role definitions and assignments
+================================
+
+*Current release: Lilac*
+
+The following roles, with corresponding expectations and assignments, are
+defined for the current release cycle.
+
+The following applies to all roles:
+
+* Communication between assignees that is pertinent to their roles must be done
+  publicly so it can be linked to, preferrably via:
+  * The [Build-Test-Release category](https://discuss.openedx.org/c/working-groups/build-test-release/30) in the forum.
+  * Github issues or PRs.
+  * The [group's Slack channel](https://openedx.slack.com/archives/C01AGTSB1LL).
+* If communication is done via video or audio, it must be recorded and posted
+  to one of the above.
+
+Group Chair
+===========
+
+*Current assignee: @arbrandes*
+
+The group chair is responsible for coordinating efforts that culminate in
+getting a new release out and maintaining the current one.  In particular, the
+Group Chair will:
+
+* Manage the current release cycle in general, including making sure that
+  proper deadlines are established and adhered to.
+* Facilitate the assignment of roles and tasks.
+* Coordinate the group's communication efforts, including running periodic
+  meetings such as the Biweekly Meetup, and summarizing recent happenings in
+  the Biweekly Update.
+* Try and help solve problems as they come up, bringing them to the attention
+  of the right group members.
+
+Release Manager
+===============
+
+*Current assignees: @nedbat and @arbrandes*
+
+The Release Manager is responsible for the actual cutting of a release, which,
+in essence, includes following the steps in the `Process to Create an Open edX Release
+<https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release>`_.
+
+In addition, the Release Manager will:
+
+* Create public test or release candidate branches as required by the release process.
+* Merge reviewed PRs into the release master branch (for instance,
+  ``open-release/koa.master``).
+* Notify the Release Testing Coordinator whenever additional testing is needed
+  in response to the above.
+* Tag releases, major and minor, at the appropriate time.
+
+Release Testing Coordinator
+===========================
+
+*Current assignee: @jfavellar90*
+
+The Release Testing Coordinator is responsible for making sure release
+candidates are tested _before_ a tag is made.  The coordinator does not
+necessarily have to run tests themselves, but they will:
+
+* Coordinate testing in general, in particular in the days leading to a timed
+  release, including the bimonthly minor ones.
+* Keep tabs on whatever CI is available, making sure it is running correctly.
+* Advocate for better testing tools and environments, when necessary.
+* Coordinate the reaction to test failures, such as bringing them to the
+  attention of the rest of the group by opening tickets or commenting in the forum.
+
+Release Documentation Expert
+============================
+
+*Current assignee: @pdpinch*
+
+The Release Documentation Expert is tasked with building the Release Notes
+document prior to a major release.  It involves:
+
+* On a best-effort basis, track down relevant information, including but not
+  limited to:
+  * Reviewing commits and pull requests across Open edX repositories.
+  * Collecting a summary of new features from the edX Product organization.
+* Writing a draft document and posting it for community review as a PR to
+  [edx-documentation](https://github.com/edx/edx-documentation/tree/master/en_us/open_edx_release_notes/source)
+  with sufficient lead time prior to a release.
+* Adjusting it as per the former review, and finally releasing a final version
+  concomittantly with the major release itself.
+
+Bug Triager
+===========
+
+*Current assignee: @BbrSofiane*
+
+The group's Bug Triager is, in a nutshell, responsible for proper use of
+the group's `issue board
+<https://github.com/openedx/build-test-release-wg/projects/1>`_.  In
+particular, they will:
+
+* Review incoming issues and ensure they have been processed accordingly (to be
+  specified separately).
+* Assist in making sure any known release bugs are tracked with individual
+  issues.  For example, if a known bug is not currently tracked, they will
+  create an issue for it with relevant information.
+* Bring the group's attention to any issues that warrant immediate action.
+* Help ping assignees when milestone deadlines are approaching.
+
+
+Community Liaison
+=================
+
+*Current assignee: @arbrandes*
+
+The Build-Test-Release Community Liaison(s) will:
+
+* Assist the Group Chair in communicating the group's progress in the forum.
+* Periodically reply to community communication in the Build-Test-Release
+  category.
+* Be on the lookout for any forum posts (not only on the
+  Build-Test-Release working group category) that credibly report
+  release-breaking issues, and communicate the issues to the `Bug
+  Triager<#bug-triager>`_.
+
+
+===========================
+Historical role assignments
+===========================
+
+Koa
+===
+
+Group Chair: @regisb
+Release Manager: @nedbat
+
+Juniper
+=======
+
+Group Chair: @regisb
+Release Manager: @nedbat

--- a/docs/decisions/0001-github-repository-and-issues.rst
+++ b/docs/decisions/0001-github-repository-and-issues.rst
@@ -1,0 +1,50 @@
+============================
+GitHub Repository and Issues
+============================
+
+-------
+Status
+-------
+
+Provisional
+
+-------
+Context
+-------
+
+The `Build-Test-Release Jira board
+<https://openedx.atlassian.net/jira/software/projects/BTR/boards/641>`_ suffers
+from a debilitating limitation: it does not allow tagging of members on issues.
+This hinders communication severely, so a different solution is required.
+Plus, usage requires an Atlassian account, which not everyone has and is,
+therefore, a significant hindrance for general community acceptance.
+
+Given that both the Community and Core Commiter working groups are moving to
+`GitHub Projects <https://github.com/features/project-management/>`_ to solve
+similar issues, it makes sense for the Build-Test-Release working group to do
+the same.
+
+Using GitHub Projects requires a repository to "back" it, and creating a
+dedicated one for this group would be a good idea even if it weren't necessary.
+For one, it will be a good place to store ADRs such as this one.
+
+---------
+Decisions
+---------
+
+1. A repository will be created for the Build-Test-Release working group in the
+   ``openedx`` organization and named ``build-test-release-wg``.
+
+2. Upon acceptance of this ADR, all new issues will be created against the
+   `Everything <https://github.com/openedx/build-test-release-wg/projects/1>`_
+   GitHub project.
+
+3. All old issues that are still relevant will be copied over from the `Jira
+   board <https://openedx.atlassian.net/jira/software/projects/BTR/boards/641>`_.
+
+------------
+Consequences
+------------
+
+It is hoped that doing this will make it easier for the group to create and
+manage tickets, and for the community in general to use it.

--- a/docs/decisions/0002-role-definitions.rst
+++ b/docs/decisions/0002-role-definitions.rst
@@ -1,0 +1,51 @@
+================================
+Role definitions and assignments
+================================
+
+-------
+Status
+-------
+
+Provisional
+
+-------
+Context
+-------
+
+The work of putting out, and then maintaining, a new Open edX release is not a
+simple endeavor, and would probably take more than a single person's full time
+dedication even if a volunteer had such time to spare.
+
+Thus, in the interest of spreading the workload with the members of the group,
+a few key roles must be created and then assigned to volunteers.
+
+---------
+Decisions
+---------
+
+#. The following roles are hereby created:
+
+   #. Group chair
+   #. Release Manager
+   #. Release Testing Coordinator
+   #. Release Documentation Expert
+   #. Bug Triager
+   #. Community Liaison
+
+#. The role descriptions will be added and maintained in this repository's
+   README.
+
+#. When volunteering, the role and its responsibilities are taken for the
+   current release cycle; i.e., until the release in development is delivered
+   by the group.  A single person can take on multiple roles, if desired, and
+   also keep said role(s) after a release is made.
+
+#. As volunteers are found, they will be added to the README for the cycle in
+   question.
+
+------------
+Consequences
+------------
+
+The distribution of tasks will make for a better and more maintainable release,
+and also closer engagement with the community.


### PR DESCRIPTION
This adds a couple of basic ADRs that document current decisions reached via meetings (or otherwise), and also defines the roles and corresponding assignments for Lilac.